### PR TITLE
Add trigram search, Discogs ID lookup, and query chain tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,18 @@ All code changes follow test-driven development. No production code without a fa
 ### Testing
 
 ```bash
-cargo test          # all tests (unit + CLI integration)
+cargo test          # all tests (unit + CLI + oracle + PG skipped without DB)
 cargo test --lib    # unit tests only
+
+# PostgreSQL integration tests (requires TEST_DATABASE_URL)
+TEST_DATABASE_URL=postgresql://musicbrainz:musicbrainz@localhost:5434/postgres \
+  cargo test --test pg_import_test
 ```
 
-Unit tests use hand-crafted JSON fixtures in each module. CLI integration tests use `tests/fixtures/small_dump.json` (5 entities: 3 music-relevant, 2 non-music).
+- **Unit tests** (26): JSON parsing, filter logic, extractor, CSV output, pipeline output trait.
+- **CLI tests** (4): End-to-end binary invocation with small_dump.json fixture.
+- **Oracle tests** (9): CSV output diffed against expected baselines in `tests/fixtures/expected/`.
+- **PG import tests** (13): Full filter -> CSV -> PG import -> query chain. Trigram search on entity names and aliases. Discogs/MusicBrainz ID lookup via indexes. Gated on `TEST_DATABASE_URL`.
 
 ### Build
 

--- a/tests/pg_import_test.rs
+++ b/tests/pg_import_test.rs
@@ -1,8 +1,11 @@
-//! PostgreSQL import integration test for wikidata-json-filter.
+//! PostgreSQL import integration tests for wikidata-json-filter.
 //!
-//! Verifies the CSV -> PG roundtrip: filter small_dump.json, produce CSVs,
-//! import each CSV into PostgreSQL via COPY, verify all 8 tables are populated
-//! and foreign key integrity holds.
+//! Verifies the full filter -> CSV -> PG import -> query chain:
+//! 1. Filter small_dump.json through the binary, producing CSVs
+//! 2. Import CSVs into PostgreSQL via COPY
+//! 3. Verify row counts, data integrity, and FK constraints
+//! 4. Verify trigram search on entity names works with pg_trgm
+//! 5. Verify Discogs ID lookup via index
 //!
 //! Gated on TEST_DATABASE_URL. Skips when the env var is unset.
 
@@ -42,9 +45,7 @@ impl TempDb {
 
 impl Drop for TempDb {
     fn drop(&mut self) {
-        if let Ok(mut client) =
-            postgres::Client::connect(&self.admin_url, postgres::NoTls)
-        {
+        if let Ok(mut client) = postgres::Client::connect(&self.admin_url, postgres::NoTls) {
             let _ = client.execute(
                 &format!(
                     "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '{}' AND pid <> pg_backend_pid()",
@@ -52,10 +53,7 @@ impl Drop for TempDb {
                 ),
                 &[],
             );
-            let _ = client.execute(
-                &format!("DROP DATABASE IF EXISTS {}", self.db_name),
-                &[],
-            );
+            let _ = client.execute(&format!("DROP DATABASE IF EXISTS {}", self.db_name), &[]);
         }
     }
 }
@@ -131,7 +129,12 @@ fn set_up_schema(client: &mut postgres::Client) {
 }
 
 /// Import a CSV file into a table via COPY.
-fn import_csv(client: &mut postgres::Client, csv_path: &std::path::Path, table: &str, columns: &str) {
+fn import_csv(
+    client: &mut postgres::Client,
+    csv_path: &std::path::Path,
+    table: &str,
+    columns: &str,
+) {
     let content = fs::read_to_string(csv_path).unwrap();
     let mut rdr = csv::ReaderBuilder::new()
         .has_headers(true)
@@ -165,7 +168,9 @@ fn import_csv(client: &mut postgres::Client, csv_path: &std::path::Path, table: 
 
 #[test]
 fn test_csv_imports_into_pg() {
-    let Some(admin_url) = test_db_url() else { return };
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
     let temp_db = TempDb::new(&admin_url);
 
     // Step 1: Generate CSVs from fixture
@@ -185,11 +190,19 @@ fn test_csv_imports_into_pg() {
     // Step 3: Import CSVs in FK order (entity first, then children)
     let imports = [
         ("entity.csv", "entity", "qid,label,description,entity_type"),
-        ("discogs_mapping.csv", "discogs_mapping", "qid,property,discogs_id"),
+        (
+            "discogs_mapping.csv",
+            "discogs_mapping",
+            "qid,property,discogs_id",
+        ),
         ("influence.csv", "influence", "source_qid,target_qid"),
         ("genre.csv", "genre", "entity_qid,genre_qid"),
         ("record_label.csv", "record_label", "artist_qid,label_qid"),
-        ("label_hierarchy.csv", "label_hierarchy", "child_qid,parent_qid"),
+        (
+            "label_hierarchy.csv",
+            "label_hierarchy",
+            "child_qid,parent_qid",
+        ),
         ("entity_alias.csv", "entity_alias", "qid,alias"),
         ("occupation.csv", "occupation", "entity_qid,occupation_qid"),
     ];
@@ -204,41 +217,67 @@ fn test_csv_imports_into_pg() {
     }
 
     // Step 4: Verify row counts
-    let row = client.query_one("SELECT COUNT(*) FROM entity", &[]).unwrap();
+    let row = client
+        .query_one("SELECT COUNT(*) FROM entity", &[])
+        .unwrap();
     let entity_count: i64 = row.get(0);
-    assert_eq!(entity_count, 3, "Expected 3 entities (Autechre, Warp Records, Stereolab)");
+    assert_eq!(
+        entity_count, 3,
+        "Expected 3 entities (Autechre, Warp Records, Stereolab)"
+    );
 
-    let row = client.query_one("SELECT COUNT(*) FROM discogs_mapping", &[]).unwrap();
+    let row = client
+        .query_one("SELECT COUNT(*) FROM discogs_mapping", &[])
+        .unwrap();
     let mapping_count: i64 = row.get(0);
     assert_eq!(mapping_count, 4, "Expected 4 external ID mappings");
 
-    let row = client.query_one("SELECT COUNT(*) FROM influence", &[]).unwrap();
+    let row = client
+        .query_one("SELECT COUNT(*) FROM influence", &[])
+        .unwrap();
     let influence_count: i64 = row.get(0);
-    assert_eq!(influence_count, 1, "Expected 1 influence (Autechre -> Q49835)");
+    assert_eq!(
+        influence_count, 1,
+        "Expected 1 influence (Autechre -> Q49835)"
+    );
 
     let row = client.query_one("SELECT COUNT(*) FROM genre", &[]).unwrap();
     let genre_count: i64 = row.get(0);
     assert_eq!(genre_count, 2, "Expected 2 genre associations");
 
-    let row = client.query_one("SELECT COUNT(*) FROM record_label", &[]).unwrap();
+    let row = client
+        .query_one("SELECT COUNT(*) FROM record_label", &[])
+        .unwrap();
     let label_count: i64 = row.get(0);
     assert_eq!(label_count, 1, "Expected 1 record label association");
 
-    let row = client.query_one("SELECT COUNT(*) FROM label_hierarchy", &[]).unwrap();
+    let row = client
+        .query_one("SELECT COUNT(*) FROM label_hierarchy", &[])
+        .unwrap();
     let hierarchy_count: i64 = row.get(0);
     assert_eq!(hierarchy_count, 1, "Expected 1 label hierarchy entry");
 
-    let row = client.query_one("SELECT COUNT(*) FROM entity_alias", &[]).unwrap();
+    let row = client
+        .query_one("SELECT COUNT(*) FROM entity_alias", &[])
+        .unwrap();
     let alias_count: i64 = row.get(0);
     assert_eq!(alias_count, 1, "Expected 1 alias (ae for Autechre)");
 
-    let row = client.query_one("SELECT COUNT(*) FROM occupation", &[]).unwrap();
+    let row = client
+        .query_one("SELECT COUNT(*) FROM occupation", &[])
+        .unwrap();
     let occ_count: i64 = row.get(0);
-    assert_eq!(occ_count, 0, "Expected 0 occupations (none of the 3 entities have musician occupation in fixture)");
+    assert_eq!(
+        occ_count, 0,
+        "Expected 0 occupations (none of the 3 entities have musician occupation in fixture)"
+    );
 
     // Step 5: Verify specific data
     let row = client
-        .query_one("SELECT label, entity_type FROM entity WHERE qid = 'Q187923'", &[])
+        .query_one(
+            "SELECT label, entity_type FROM entity WHERE qid = 'Q187923'",
+            &[],
+        )
         .unwrap();
     let label: &str = row.get(0);
     let entity_type: &str = row.get(1);
@@ -246,7 +285,10 @@ fn test_csv_imports_into_pg() {
     assert_eq!(entity_type, "group");
 
     let row = client
-        .query_one("SELECT label, entity_type FROM entity WHERE qid = 'Q1312934'", &[])
+        .query_one(
+            "SELECT label, entity_type FROM entity WHERE qid = 'Q1312934'",
+            &[],
+        )
         .unwrap();
     let label: &str = row.get(0);
     let entity_type: &str = row.get(1);
@@ -287,13 +329,21 @@ fn test_csv_imports_into_pg() {
         .unwrap();
     assert_eq!(rows.len(), 2);
     let props: HashSet<String> = rows.iter().map(|r| r.get::<_, String>(0)).collect();
-    assert!(props.contains("P1953"), "Autechre should have Discogs artist ID");
-    assert!(props.contains("P434"), "Autechre should have MusicBrainz ID");
+    assert!(
+        props.contains("P1953"),
+        "Autechre should have Discogs artist ID"
+    );
+    assert!(
+        props.contains("P434"),
+        "Autechre should have MusicBrainz ID"
+    );
 }
 
 #[test]
 fn test_all_eight_tables_populated_or_empty() {
-    let Some(admin_url) = test_db_url() else { return };
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
     let temp_db = TempDb::new(&admin_url);
 
     let output_dir = tempfile::tempdir().unwrap();
@@ -310,11 +360,19 @@ fn test_all_eight_tables_populated_or_empty() {
 
     let imports = [
         ("entity.csv", "entity", "qid,label,description,entity_type"),
-        ("discogs_mapping.csv", "discogs_mapping", "qid,property,discogs_id"),
+        (
+            "discogs_mapping.csv",
+            "discogs_mapping",
+            "qid,property,discogs_id",
+        ),
         ("influence.csv", "influence", "source_qid,target_qid"),
         ("genre.csv", "genre", "entity_qid,genre_qid"),
         ("record_label.csv", "record_label", "artist_qid,label_qid"),
-        ("label_hierarchy.csv", "label_hierarchy", "child_qid,parent_qid"),
+        (
+            "label_hierarchy.csv",
+            "label_hierarchy",
+            "child_qid,parent_qid",
+        ),
         ("entity_alias.csv", "entity_alias", "qid,alias"),
         ("occupation.csv", "occupation", "entity_qid,occupation_qid"),
     ];
@@ -354,7 +412,15 @@ fn test_all_eight_tables_populated_or_empty() {
     }
 
     // Populated tables should have > 0 rows
-    let populated = ["entity", "discogs_mapping", "influence", "genre", "record_label", "label_hierarchy", "entity_alias"];
+    let populated = [
+        "entity",
+        "discogs_mapping",
+        "influence",
+        "genre",
+        "record_label",
+        "label_hierarchy",
+        "entity_alias",
+    ];
     for table in &populated {
         let row = client
             .query_one(&format!("SELECT COUNT(*) FROM {}", table), &[])
@@ -366,4 +432,347 @@ fn test_all_eight_tables_populated_or_empty() {
             table
         );
     }
+}
+
+// --- Index and query pattern tests ---
+
+/// Create the indexes that downstream consumers (wikidata-cache) use for querying.
+fn create_indexes(client: &mut postgres::Client) {
+    client
+        .batch_execute(
+            "CREATE EXTENSION IF NOT EXISTS pg_trgm;
+             CREATE INDEX IF NOT EXISTS idx_entity_label_trgm ON entity USING gin (label gin_trgm_ops);
+             CREATE INDEX IF NOT EXISTS idx_entity_alias_trgm ON entity_alias USING gin (alias gin_trgm_ops);
+             CREATE INDEX IF NOT EXISTS idx_discogs_mapping_property_id ON discogs_mapping (property, discogs_id);
+             CREATE INDEX IF NOT EXISTS idx_discogs_mapping_qid ON discogs_mapping (qid);",
+        )
+        .unwrap();
+}
+
+/// Helper: set up a full test database with schema, data, and indexes.
+fn set_up_full_db(admin_url: &str) -> (TempDb, postgres::Client) {
+    let temp_db = TempDb::new(admin_url);
+
+    let output_dir = tempfile::tempdir().unwrap();
+    Command::cargo_bin("wikidata-json-filter")
+        .unwrap()
+        .arg(fixture_path("small_dump.json"))
+        .arg("--output-dir")
+        .arg(output_dir.path())
+        .assert()
+        .success();
+
+    let mut client = postgres::Client::connect(&temp_db.url, postgres::NoTls).unwrap();
+    set_up_schema(&mut client);
+
+    let imports = [
+        ("entity.csv", "entity", "qid,label,description,entity_type"),
+        (
+            "discogs_mapping.csv",
+            "discogs_mapping",
+            "qid,property,discogs_id",
+        ),
+        ("influence.csv", "influence", "source_qid,target_qid"),
+        ("genre.csv", "genre", "entity_qid,genre_qid"),
+        ("record_label.csv", "record_label", "artist_qid,label_qid"),
+        (
+            "label_hierarchy.csv",
+            "label_hierarchy",
+            "child_qid,parent_qid",
+        ),
+        ("entity_alias.csv", "entity_alias", "qid,alias"),
+        ("occupation.csv", "occupation", "entity_qid,occupation_qid"),
+    ];
+
+    for (csv_file, table, columns) in &imports {
+        import_csv(
+            &mut client,
+            &output_dir.path().join(csv_file),
+            table,
+            columns,
+        );
+    }
+
+    create_indexes(&mut client);
+    (temp_db, client)
+}
+
+#[test]
+fn test_trigram_search_exact_match() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Exact name search using trigram similarity
+    let rows = client
+        .query(
+            "SELECT qid, label FROM entity WHERE label % $1 ORDER BY similarity(label, $1) DESC",
+            &[&"Autechre"],
+        )
+        .unwrap();
+    assert!(
+        !rows.is_empty(),
+        "Trigram search for 'Autechre' should return results"
+    );
+    assert_eq!(
+        rows[0].get::<_, &str>(1),
+        "Autechre",
+        "Best match should be exact"
+    );
+}
+
+#[test]
+fn test_trigram_search_fuzzy_match() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Fuzzy search: "Autechree" (typo) should still find "Autechre"
+    let rows = client
+        .query(
+            "SELECT qid, label, similarity(label, $1) as sim \
+             FROM entity \
+             WHERE label % $1 \
+             ORDER BY sim DESC",
+            &[&"Autechree"],
+        )
+        .unwrap();
+    assert!(
+        !rows.is_empty(),
+        "Trigram search for 'Autechree' (typo) should find 'Autechre'"
+    );
+    let best_label: &str = rows[0].get(1);
+    assert_eq!(best_label, "Autechre");
+}
+
+#[test]
+fn test_trigram_search_partial_match() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Partial search: "Stereo" should find "Stereolab" via ILIKE or trigram
+    let rows = client
+        .query(
+            "SELECT qid, label FROM entity WHERE label ILIKE $1",
+            &[&"%Stereo%"],
+        )
+        .unwrap();
+    assert!(
+        !rows.is_empty(),
+        "ILIKE search for '%Stereo%' should find 'Stereolab'"
+    );
+    let labels: Vec<&str> = rows.iter().map(|r| r.get(1)).collect();
+    assert!(labels.contains(&"Stereolab"));
+}
+
+#[test]
+fn test_trigram_search_on_aliases() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Search aliases: "ae" is an alias for Autechre (Q187923)
+    let rows = client
+        .query(
+            "SELECT e.qid, e.label FROM entity_alias a \
+             JOIN entity e ON e.qid = a.qid \
+             WHERE a.alias % $1 \
+             ORDER BY similarity(a.alias, $1) DESC",
+            &[&"ae"],
+        )
+        .unwrap();
+    assert!(
+        !rows.is_empty(),
+        "Trigram search on aliases for 'ae' should find Autechre"
+    );
+    assert_eq!(rows[0].get::<_, &str>(0), "Q187923");
+    assert_eq!(rows[0].get::<_, &str>(1), "Autechre");
+}
+
+#[test]
+fn test_discogs_id_lookup_by_artist_id() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Look up entity by Discogs artist ID (P1953)
+    let rows = client
+        .query(
+            "SELECT e.qid, e.label, e.entity_type \
+             FROM discogs_mapping dm \
+             JOIN entity e ON e.qid = dm.qid \
+             WHERE dm.property = 'P1953' AND dm.discogs_id = $1",
+            &[&"12"],
+        )
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "Discogs artist ID 12 should match one entity"
+    );
+    assert_eq!(rows[0].get::<_, &str>(0), "Q187923");
+    assert_eq!(rows[0].get::<_, &str>(1), "Autechre");
+    assert_eq!(rows[0].get::<_, &str>(2), "group");
+}
+
+#[test]
+fn test_discogs_id_lookup_by_label_id() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Look up entity by Discogs label ID (P1902)
+    let rows = client
+        .query(
+            "SELECT e.qid, e.label, e.entity_type \
+             FROM discogs_mapping dm \
+             JOIN entity e ON e.qid = dm.qid \
+             WHERE dm.property = 'P1902' AND dm.discogs_id = $1",
+            &[&"23528"],
+        )
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "Discogs label ID 23528 should match one entity"
+    );
+    assert_eq!(rows[0].get::<_, &str>(0), "Q1312934");
+    assert_eq!(rows[0].get::<_, &str>(1), "Warp Records");
+    assert_eq!(rows[0].get::<_, &str>(2), "label");
+}
+
+#[test]
+fn test_discogs_id_lookup_nonexistent() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Look up a Discogs ID that doesn't exist
+    let rows = client
+        .query(
+            "SELECT qid FROM discogs_mapping WHERE property = 'P1953' AND discogs_id = $1",
+            &[&"99999999"],
+        )
+        .unwrap();
+    assert!(
+        rows.is_empty(),
+        "Nonexistent Discogs ID should return no results"
+    );
+}
+
+#[test]
+fn test_musicbrainz_id_lookup() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Look up entity by MusicBrainz artist ID (P434)
+    let rows = client
+        .query(
+            "SELECT e.qid, e.label FROM discogs_mapping dm \
+             JOIN entity e ON e.qid = dm.qid \
+             WHERE dm.property = 'P434' AND dm.discogs_id = $1",
+            &[&"410c9baf-5469-44f6-9852-826524b80c61"],
+        )
+        .unwrap();
+    assert_eq!(rows.len(), 1, "MusicBrainz ID should match Autechre");
+    assert_eq!(rows[0].get::<_, &str>(1), "Autechre");
+}
+
+#[test]
+fn test_indexes_exist_after_creation() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    let rows = client
+        .query(
+            "SELECT indexname FROM pg_indexes WHERE schemaname = 'public' ORDER BY indexname",
+            &[],
+        )
+        .unwrap();
+    let index_names: Vec<String> = rows.iter().map(|r| r.get(0)).collect();
+
+    assert!(
+        index_names.contains(&"idx_entity_label_trgm".to_string()),
+        "Trigram index on entity.label should exist"
+    );
+    assert!(
+        index_names.contains(&"idx_entity_alias_trgm".to_string()),
+        "Trigram index on entity_alias.alias should exist"
+    );
+    assert!(
+        index_names.contains(&"idx_discogs_mapping_property_id".to_string()),
+        "Composite index on discogs_mapping(property, discogs_id) should exist"
+    );
+    assert!(
+        index_names.contains(&"idx_discogs_mapping_qid".to_string()),
+        "Index on discogs_mapping(qid) should exist"
+    );
+}
+
+#[test]
+fn test_index_used_for_discogs_lookup() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // EXPLAIN should show Index Scan for the Discogs ID lookup
+    let rows = client
+        .query(
+            "EXPLAIN SELECT qid FROM discogs_mapping WHERE property = 'P1953' AND discogs_id = '12'",
+            &[],
+        )
+        .unwrap();
+    let plan: String = rows
+        .iter()
+        .map(|r| r.get::<_, String>(0))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // With only 4 rows the planner may choose Seq Scan, so we just verify the
+    // query succeeds and the index exists (already tested above). For large
+    // datasets the planner would use the index.
+    assert!(!plan.is_empty(), "EXPLAIN should return a query plan");
+}
+
+#[test]
+fn test_full_filter_csv_pg_query_chain() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Full chain: filter -> CSV -> PG -> trigram search -> join with Discogs ID
+    // Find "Stereolab" via trigram, then look up its Discogs artist ID
+    let rows = client
+        .query(
+            "SELECT e.qid, e.label, dm.property, dm.discogs_id \
+             FROM entity e \
+             JOIN discogs_mapping dm ON dm.qid = e.qid \
+             WHERE e.label % $1 AND dm.property = 'P1953' \
+             ORDER BY similarity(e.label, $1) DESC",
+            &[&"Stereolab"],
+        )
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "Should find exactly one Stereolab + Discogs match"
+    );
+    assert_eq!(rows[0].get::<_, &str>(0), "Q643023");
+    assert_eq!(rows[0].get::<_, &str>(1), "Stereolab");
+    assert_eq!(rows[0].get::<_, &str>(2), "P1953");
+    assert_eq!(rows[0].get::<_, &str>(3), "4965");
 }


### PR DESCRIPTION
## Summary

- Expand `tests/pg_import_test.rs` with **11 new tests** covering the downstream query patterns that wikidata-cache consumers rely on.
- **Trigram search tests**: Verify `pg_trgm`-powered fuzzy matching on entity labels (exact match, fuzzy with typos like "Autechree", partial via ILIKE) and aliases (the "ae" alias resolves to Autechre via `entity_alias` join).
- **Discogs ID lookup tests**: Verify indexed lookups by P1953 (Discogs artist ID), P1902 (Discogs label ID), P434 (MusicBrainz artist ID). Also verifies nonexistent IDs return empty results.
- **Index verification tests**: Confirm the 4 required indexes (`idx_entity_label_trgm`, `idx_entity_alias_trgm`, `idx_discogs_mapping_property_id`, `idx_discogs_mapping_qid`) exist after creation.
- **Full chain test**: Exercises the complete filter -> CSV -> PG import -> trigram search -> Discogs ID join pipeline in a single test (finds Stereolab via trigram, looks up its Discogs artist ID 4965).
- All PG tests use per-test temporary databases and are gated on `TEST_DATABASE_URL`.

## Test plan

- [x] `cargo test` passes (52 total tests: 26 unit + 4 CLI + 9 oracle + 13 PG)
- [x] `TEST_DATABASE_URL=... cargo test --test pg_import_test` passes (13 PG tests against real database)
- [x] `cargo fmt --check` and `cargo clippy` clean