### PR TITLE
Add EXPLAIN-based assertions that schema indexes are actually used

### DIFF
--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -39,7 +39,9 @@ fn corrupted_gzip_returns_gracefully_not_panic() {
     // Stderr should contain the read error warning
     let stderr = String::from_utf8_lossy(&output.get_output().stderr);
     assert!(
-        stderr.contains("read error") || stderr.contains("truncated stream") || stderr.contains("corrupt"),
+        stderr.contains("read error")
+            || stderr.contains("truncated stream")
+            || stderr.contains("corrupt"),
         "Expected warning about corrupted stream in stderr, got: {}",
         stderr
     );

--- a/tests/pg_import_test.rs
+++ b/tests/pg_import_test.rs
@@ -747,6 +747,108 @@ fn test_index_used_for_discogs_lookup() {
     assert!(!plan.is_empty(), "EXPLAIN should return a query plan");
 }
 
+/// Run `EXPLAIN <query>` (default text format) and join the lines into one
+/// string for substring assertions. Plain text format avoids needing the
+/// `postgres` crate's optional `with-serde_json-1` feature.
+fn explain_plan_text(client: &mut postgres::Client, query: &str) -> String {
+    let rows = client.query(&format!("EXPLAIN {}", query), &[]).unwrap();
+    rows.iter()
+        .map(|r| r.get::<_, String>(0))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn test_explain_uses_index_for_discogs_lookup() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Insert ~500 synthetic discogs_mapping rows so the planner prefers the
+    // composite index over a sequential scan. Each synthetic row needs a parent
+    // entity row to satisfy the FK on discogs_mapping.qid.
+    client
+        .batch_execute(
+            "INSERT INTO entity (qid, label, description, entity_type)
+             SELECT 'Q9' || g::text, 'synthetic_' || g::text, '', 'group'
+             FROM generate_series(1, 500) g;
+             INSERT INTO discogs_mapping (qid, property, discogs_id)
+             SELECT 'Q9' || g::text, 'P1953', (1000000 + g)::text
+             FROM generate_series(1, 500) g;
+             REINDEX INDEX idx_discogs_mapping_property_id;
+             ANALYZE entity;
+             ANALYZE discogs_mapping;",
+        )
+        .unwrap();
+
+    let plan = explain_plan_text(
+        &mut client,
+        "SELECT qid FROM discogs_mapping \
+         WHERE property = 'P1953' AND discogs_id = '1000123'",
+    );
+
+    let uses_index = plan.contains("Index Scan")
+        || plan.contains("Bitmap Index Scan")
+        || plan.contains("Index Only Scan");
+    assert!(
+        uses_index,
+        "Expected EXPLAIN plan to include an index-scan node.\nPlan:\n{}",
+        plan
+    );
+
+    assert!(
+        plan.contains("idx_discogs_mapping_property_id"),
+        "Expected plan to reference idx_discogs_mapping_property_id.\nPlan:\n{}",
+        plan
+    );
+}
+
+#[test]
+fn test_explain_uses_trigram_index_for_label_search() {
+    let Some(admin_url) = test_db_url() else {
+        return;
+    };
+    let (_temp_db, mut client) = set_up_full_db(&admin_url);
+
+    // Insert ~20k entities with diverse synthetic labels so the GIN trigram
+    // index beats a sequential scan (GIN has noticeable startup cost, so the
+    // table has to be large enough that scanning it linearly is slower).
+    // Use md5() to vary trigrams across rows. After bulk insert we REINDEX so
+    // the GIN index is compact (incremental GIN inserts bloat the index, which
+    // inflates the planner's estimated cost and can defeat this assertion).
+    client
+        .batch_execute(
+            "INSERT INTO entity (qid, label, description, entity_type)
+             SELECT 'Q8' || g::text,
+                    'synth_' || md5(g::text) || '_band',
+                    '',
+                    'group'
+             FROM generate_series(1, 20000) g;
+             REINDEX INDEX idx_entity_label_trgm;
+             ANALYZE entity;",
+        )
+        .unwrap();
+
+    // Trigram similarity match against the seeded fixture name 'Autechre'. The
+    // % operator is what idx_entity_label_trgm (gin_trgm_ops) accelerates.
+    let plan = explain_plan_text(
+        &mut client,
+        "SELECT qid, label FROM entity WHERE label % 'autechre'",
+    );
+
+    assert!(
+        plan.contains("Bitmap Index Scan"),
+        "Expected a Bitmap Index Scan in the plan.\nPlan:\n{}",
+        plan
+    );
+    assert!(
+        plan.contains("idx_entity_label_trgm"),
+        "Expected the plan to reference idx_entity_label_trgm.\nPlan:\n{}",
+        plan
+    );
+}
+
 #[test]
 fn test_full_filter_csv_pg_query_chain() {
     let Some(admin_url) = test_db_url() else {


### PR DESCRIPTION
## Summary

The existing `test_index_used_for_discogs_lookup` only verifies that `EXPLAIN` returns *some* query plan -- with the fixture's ~4 rows the planner picks Seq Scan, so the assertion passes whether or not the index would ever be useful in production. This PR adds two tests that defeat the small-table seq-scan preference and assert the chosen plan actually references the named indexes.

`test_explain_uses_index_for_discogs_lookup` seeds 500 synthetic `discogs_mapping` rows (plus parent `entity` rows for the FK) and asserts the plan for `WHERE property = 'P1953' AND discogs_id = '...'` uses an index-scan node and references `idx_discogs_mapping_property_id`.

`test_explain_uses_trigram_index_for_label_search` seeds 20k entities with md5-derived labels, REINDEXes the GIN trigram index so incremental insert bloat doesn't inflate the planner's cost estimate, and asserts the plan for `WHERE label %% 'autechre'` uses a Bitmap Index Scan on `idx_entity_label_trgm`.

Both tests use plain-text `EXPLAIN` output and substring matching for portability across PG versions, avoiding the optional `with-serde_json-1` feature on the postgres crate.

Also picks up a stray `cargo fmt` fix for `tests/error_handling.rs`.

Closes #7

## Test plan

- [x] `cargo build --tests`
- [x] `cargo clippy --tests` (no new warnings)
- [x] `cargo fmt --check`
- [x] `TEST_DATABASE_URL=postgresql://wikidata:wikidata@localhost:5435/postgres cargo test --test pg_import_test` -> 15/15 pass (2 new + 13 pre-existing)
- [x] `cargo test` (no DB) -> all suites pass; PG-gated tests early-return as designed