### PR TITLE
chore: rename to wikidata-cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# Claude Code Instructions for wikidata-json-filter
+# Claude Code Instructions for wikidata-cache
 
 ## Project Overview
 
-Purpose-built Rust tool for filtering Wikidata JSON data dumps to music-relevant entities, producing CSV files compatible with the [wikidata-cache](https://github.com/WXYC/wikidata-cache) ETL pipeline. Also provides an `import` subcommand to load those CSVs into PostgreSQL, creating the wikidata-cache database. Analogous to [discogs-xml-converter](https://github.com/WXYC/discogs-xml-converter) for Discogs data.
+Purpose-built Rust tool that builds the WXYC `wikidata-cache` PostgreSQL database from Wikidata JSON dumps. Two subcommands: the default mode streams a (gzipped) Wikidata JSON dump and writes 8 CSV files of music-relevant entities; the `import` subcommand loads those CSVs into PostgreSQL. Analogous to [discogs-xml-converter](https://github.com/WXYC/discogs-xml-converter) for Discogs data and [musicbrainz-cache](https://github.com/WXYC/musicbrainz-cache) for MusicBrainz.
 
 ## Architecture
 
@@ -96,7 +96,7 @@ TEST_DATABASE_URL=postgresql://musicbrainz:musicbrainz@localhost:5434/postgres \
 ### Build
 
 ```bash
-cargo build --release   # produces target/release/wikidata-json-filter
+cargo build --release   # produces target/release/wikidata-cache
 cargo install --path .  # installs to ~/.cargo/bin/
 ```
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1491,7 +1491,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "wikidata-json-filter"
+name = "wikidata-cache"
 version = "0.1.0"
 dependencies = [
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "wikidata-json-filter"
+name = "wikidata-cache"
 version = "0.1.0"
 edition = "2024"
-description = "Streaming filter for Wikidata JSON dumps — extracts music-relevant entities to CSV"
+description = "Streaming filter for Wikidata JSON dumps + PostgreSQL cache builder for music-relevant entities"
 license = "MIT"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# wikidata-json-filter
+# wikidata-cache
 
 Streaming Rust filter for [Wikidata JSON data dumps](https://www.wikidata.org/wiki/Wikidata:Database_download). Extracts music-relevant entities (artists, bands, record labels) and writes flat CSV files, then loads them into PostgreSQL to create the wikidata-cache database.
 
@@ -8,13 +8,13 @@ Analogous to [discogs-xml-converter](https://github.com/WXYC/discogs-xml-convert
 
 ```bash
 # Filter the full Wikidata dump (~130GB gzipped, ~3 hours)
-wikidata-json-filter latest-all.json.gz --output-dir /path/to/csv/
+wikidata-cache latest-all.json.gz --output-dir /path/to/csv/
 
 # Limit entities for testing
-wikidata-json-filter latest-all.json.gz --output-dir /tmp/test/ --limit 1000
+wikidata-cache latest-all.json.gz --output-dir /tmp/test/ --limit 1000
 
 # Adjust progress logging interval
-wikidata-json-filter latest-all.json.gz --output-dir /path/to/csv/ --progress-interval 500000
+wikidata-cache latest-all.json.gz --output-dir /path/to/csv/ --progress-interval 500000
 ```
 
 Gzipped input is auto-detected by `.gz` extension.
@@ -61,14 +61,14 @@ The `import` subcommand loads the CSV output directly into PostgreSQL:
 
 ```bash
 # Import CSVs into PostgreSQL (creates schema, imports data, runs VACUUM)
-wikidata-json-filter import --csv-dir /path/to/csv/ --database-url 'host=localhost dbname=wikidata user=wikidata password=wikidata'
+wikidata-cache import --csv-dir /path/to/csv/ --database-url 'host=localhost dbname=wikidata user=wikidata password=wikidata'
 
 # Or use DATABASE_URL environment variable
 export DATABASE_URL='host=localhost dbname=wikidata user=wikidata password=wikidata'
-wikidata-json-filter import --csv-dir /path/to/csv/
+wikidata-cache import --csv-dir /path/to/csv/
 
 # Drop and recreate schema before importing
-wikidata-json-filter import --csv-dir /path/to/csv/ --database-url '...' --fresh
+wikidata-cache import --csv-dir /path/to/csv/ --database-url '...' --fresh
 ```
 
 The import:
@@ -125,10 +125,10 @@ Unit and CLI tests use hand-written JSON fixtures; no external data dumps needed
 wget https://dumps.wikimedia.org/wikidatawiki/entities/latest-all.json.gz
 
 # 2. Filter to music entities
-wikidata-json-filter latest-all.json.gz --output-dir /path/to/csv/
+wikidata-cache latest-all.json.gz --output-dir /path/to/csv/
 
 # 3. Load into PostgreSQL
-wikidata-json-filter import --csv-dir /path/to/csv/ --database-url 'host=localhost dbname=wikidata user=wikidata password=wikidata' --fresh
+wikidata-cache import --csv-dir /path/to/csv/ --database-url 'host=localhost dbname=wikidata user=wikidata password=wikidata' --fresh
 ```
 
 ## Data source

--- a/schema/create_database.sql
+++ b/schema/create_database.sql
@@ -1,6 +1,6 @@
 -- wikidata-cache PostgreSQL schema
--- Creates tables for music-relevant Wikidata entities extracted by wikidata-json-filter.
--- Compatible with the 8 CSV files produced by wikidata-json-filter's writer module.
+-- Creates tables for music-relevant Wikidata entities extracted by wikidata-cache.
+-- Compatible with the 8 CSV files produced by wikidata-cache's writer module.
 
 CREATE EXTENSION IF NOT EXISTS pg_trgm;
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,4 +1,4 @@
-//! CSV import module: reads the 8 CSV files produced by wikidata-json-filter
+//! CSV import module: reads the 8 CSV files produced by wikidata-cache
 //! and streams them into PostgreSQL via COPY.
 
 use anyhow::{Context, Result};

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,15 +16,15 @@ use std::time::Instant;
 
 use wxyc_etl::pipeline::{self, BatchConfig};
 
-use wikidata_json_filter::extractor::extract;
-use wikidata_json_filter::filter::is_music_relevant;
-use wikidata_json_filter::import;
-use wikidata_json_filter::import_schema;
-use wikidata_json_filter::model::Entity;
-use wikidata_json_filter::writer::CsvOutput;
+use wikidata_cache::extractor::extract;
+use wikidata_cache::filter::is_music_relevant;
+use wikidata_cache::import;
+use wikidata_cache::import_schema;
+use wikidata_cache::model::Entity;
+use wikidata_cache::writer::CsvOutput;
 
 #[derive(Parser)]
-#[command(name = "wikidata-json-filter")]
+#[command(name = "wikidata-cache")]
 #[command(about = "Filter Wikidata JSON dumps to music-relevant entities")]
 struct Cli {
     #[command(subcommand)]

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -6,7 +6,7 @@ use tempfile::TempDir;
 fn filters_small_dump() {
     let output_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg("tests/fixtures/small_dump.json")
         .arg("--output-dir")
@@ -51,7 +51,7 @@ fn filters_small_dump() {
 fn limit_flag_stops_early() {
     let output_dir = TempDir::new().unwrap();
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg("tests/fixtures/small_dump.json")
         .arg("--output-dir")
@@ -75,7 +75,7 @@ fn stdin_piping() {
     let output_dir = TempDir::new().unwrap();
     let input = fs::read("tests/fixtures/small_dump.json").unwrap();
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg("-")
         .arg("--output-dir")
@@ -95,7 +95,7 @@ fn stdin_piping() {
 
 #[test]
 fn missing_input_fails() {
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg("nonexistent.json")
         .assert()

--- a/tests/error_handling.rs
+++ b/tests/error_handling.rs
@@ -1,4 +1,4 @@
-//! Error handling tests for wikidata-json-filter.
+//! Error handling tests for wikidata-cache.
 //!
 //! Verifies graceful behavior on corrupted gzip input and malformed JSON entities.
 
@@ -27,7 +27,7 @@ fn corrupted_gzip_returns_gracefully_not_panic() {
     // The binary should handle corrupted gzip gracefully -- it prints a warning
     // about the truncated stream and exits with success (0 entities processed).
     // The key assertion is that it does NOT panic or hang.
-    let output = Command::cargo_bin("wikidata-json-filter")
+    let output = Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(corrupted_path.to_str().unwrap())
         .arg("--output-dir")
@@ -55,7 +55,7 @@ fn corrupted_gzip_produces_no_output_files_or_empty() {
     let corrupted_path = input_dir.path().join("bad.json.gz");
     create_corrupted_gzip(&corrupted_path);
 
-    let _ = Command::cargo_bin("wikidata-json-filter")
+    let _ = Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(corrupted_path.to_str().unwrap())
         .arg("--output-dir")
@@ -92,7 +92,7 @@ fn malformed_json_entity_skipped_with_warning() {
     let dump_path = input_dir.path().join("malformed.json");
     fs::write(&dump_path, dump).unwrap();
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(dump_path.to_str().unwrap())
         .arg("--output-dir")
@@ -129,7 +129,7 @@ fn empty_json_array_produces_empty_output() {
     let dump_path = input_dir.path().join("empty.json");
     fs::write(&dump_path, "[\n]\n").unwrap();
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(dump_path.to_str().unwrap())
         .arg("--output-dir")
@@ -160,7 +160,7 @@ fn entity_with_missing_labels_field_skipped() {
     let dump_path = input_dir.path().join("missing_labels.json");
     fs::write(&dump_path, dump).unwrap();
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(dump_path.to_str().unwrap())
         .arg("--output-dir")

--- a/tests/import_test.rs
+++ b/tests/import_test.rs
@@ -10,8 +10,8 @@ use assert_cmd::Command;
 use postgres::{Client, NoTls};
 use std::path::Path;
 use std::sync::{Mutex, MutexGuard};
-use wikidata_json_filter::import;
-use wikidata_json_filter::import_schema;
+use wikidata_cache::import;
+use wikidata_cache::import_schema;
 
 const TEST_DB_URL: &str =
     "host=localhost port=5435 user=wikidata password=wikidata dbname=wikidata_test";
@@ -552,10 +552,10 @@ fn test_vacuum_after_import() {
 fn test_end_to_end_pipeline() {
     let _lock = lock_db();
 
-    // Step 1: Run wikidata-json-filter on the small JSON dump to produce CSVs
+    // Step 1: Run wikidata-cache on the small JSON dump to produce CSVs
     let csv_dir = tempfile::TempDir::new().unwrap();
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg("tests/fixtures/small_dump.json")
         .arg("--output-dir")
@@ -650,7 +650,7 @@ fn test_import_subcommand() {
     import_schema::drop_schema(&mut client).unwrap();
     drop(client);
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg("import")
         .arg("--csv-dir")

--- a/tests/oracle_tests.rs
+++ b/tests/oracle_tests.rs
@@ -57,7 +57,7 @@ fn generate_output() -> tempfile::TempDir {
     let dir = tempfile::tempdir().unwrap();
     let input = fixture_path("small_dump.json");
 
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(input)
         .arg("--output-dir")

--- a/tests/pg_import_test.rs
+++ b/tests/pg_import_test.rs
@@ -1,4 +1,4 @@
-//! PostgreSQL import integration tests for wikidata-json-filter.
+//! PostgreSQL import integration tests for wikidata-cache.
 //!
 //! Verifies the full filter -> CSV -> PG import -> query chain:
 //! 1. Filter small_dump.json through the binary, producing CSVs
@@ -175,7 +175,7 @@ fn test_csv_imports_into_pg() {
 
     // Step 1: Generate CSVs from fixture
     let output_dir = tempfile::tempdir().unwrap();
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(fixture_path("small_dump.json"))
         .arg("--output-dir")
@@ -347,7 +347,7 @@ fn test_all_eight_tables_populated_or_empty() {
     let temp_db = TempDb::new(&admin_url);
 
     let output_dir = tempfile::tempdir().unwrap();
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(fixture_path("small_dump.json"))
         .arg("--output-dir")
@@ -454,7 +454,7 @@ fn set_up_full_db(admin_url: &str) -> (TempDb, postgres::Client) {
     let temp_db = TempDb::new(admin_url);
 
     let output_dir = tempfile::tempdir().unwrap();
-    Command::cargo_bin("wikidata-json-filter")
+    Command::cargo_bin("wikidata-cache")
         .unwrap()
         .arg(fixture_path("small_dump.json"))
         .arg("--output-dir")


### PR DESCRIPTION
## Summary

- Renames the GitHub repo from `wikidata-json-filter` to `wikidata-cache` (already done — old URLs auto-redirect).
- Renames the Cargo package, binary (`target/release/wikidata-cache`), and lib import path (`wikidata_cache::…`) to match.
- Updates README, CLAUDE.md, SQL schema comments, src/import.rs comment, and all test references.
- The new name reflects what the repo actually delivers: a PostgreSQL cache of music-relevant Wikidata entities built from JSON dumps. Matches the sister repo naming (`musicbrainz-cache`).

Closes #15.

## Test plan

- [x] `cargo build` (succeeds with new package + binary names)
- [x] `cargo test --lib --bins --test cli_tests --test oracle_tests --test error_handling`
- [x] `cargo run --bin wikidata-cache -- --help` (correct binary name + clap command name)
- [x] `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings`
- [x] `https://github.com/WXYC/wikidata-json-filter` redirects to `https://github.com/WXYC/wikidata-cache` (verified via `curl -L`)
- [ ] CI green

## Follow-up

Unblocks the consumer rename PRs (`semantic-index#199`, `library-metadata-lookup#177`, `wxyc-etl#52`, `discogs-etl#116`, `wxyc-etl#53`) and the in-repo Sentry/CLI migrations (`#13`, `#14`).

Anyone with a local clone needs `git remote set-url origin git@github.com:WXYC/wikidata-cache.git`.