### PR TITLE
Add monthly rebuild cron workflow

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -1,0 +1,61 @@
+name: Rebuild wikidata-cache
+
+# Monthly full rebuild of the wikidata-cache PostgreSQL database from a
+# Wikidata JSON dump. Runs `wikidata-cache build` (filter dump -> 8 CSVs) then
+# `wikidata-cache import --fresh` (drop + reload schema + COPY CSVs).
+#
+# Sister cache rebuild schedules (stagger to avoid co-running multi-hour jobs):
+#   - discogs-etl:        TBD (1st-ish)
+#   - musicbrainz-cache:  TBD (5th-ish)
+#   - wikidata-cache:     10th of the month (this workflow)
+#
+# TODO(runner-capacity): The Wikidata JSON dump is ~130GB gzipped and the full
+# build + import can run for many hours. GitHub-hosted `ubuntu-latest` runners
+# have a 6-hour job timeout and ~14GB free disk. This workflow is a scheduling
+# skeleton; the actual rebuild likely needs to move to a self-hosted runner, a
+# Railway job, or a dedicated EC2 box. Until then, expect scheduled runs to
+# fail on disk or timeout — operators should kick rebuilds manually elsewhere
+# and use this workflow's `workflow_dispatch` for small-dump smoke tests.
+
+on:
+  schedule:
+    # 06:00 UTC on the 10th of each month (offset from sister cache rebuilds)
+    - cron: "0 6 10 * *"
+  workflow_dispatch:
+    inputs:
+      dump_url:
+        description: "Wikidata dump URL (default: latest-all.json.gz)"
+        required: false
+        default: "https://dumps.wikimedia.org/wikidatawiki/entities/latest-all.json.gz"
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    # TODO(runner-capacity): see top-of-file note. 360 minutes is the max for
+    # GitHub-hosted runners; real rebuilds will exceed this.
+    timeout-minutes: 350
+    env:
+      DUMP_URL: ${{ inputs.dump_url || 'https://dumps.wikimedia.org/wikidatawiki/entities/latest-all.json.gz' }}
+      DATA_DIR: ${{ github.workspace }}/data
+      DATABASE_URL_WIKIDATA: ${{ secrets.DATABASE_URL_WIKIDATA }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout wxyc-etl at expected relative path
+        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../wxyc-etl"
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Build release binary
+        run: cargo build --release
+
+      - name: Prepare data directory
+        run: mkdir -p "$DATA_DIR"
+
+      - name: Build CSVs from Wikidata dump
+        # Stream the dump via stdin so we don't need disk space for the
+        # ~130GB gzipped file in addition to the CSV output.
+        run: curl -fsSL "$DUMP_URL" | ./target/release/wikidata-cache build - --data-dir "$DATA_DIR" --gzip
+
+      - name: Import CSVs into PostgreSQL
+        run: ./target/release/wikidata-cache import --data-dir "$DATA_DIR" --fresh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,12 @@ An entity is music-relevant if it has ANY primary indicator (each sufficient on 
 
 Secondary properties (P737 influence, P136 genre, P264 record label, P749 parent org, P2850 Apple Music artist ID, P3283 Bandcamp profile ID) are extracted only from entities that pass the primary filter. They don't independently qualify an entity.
 
+## Scheduling
+
+The full rebuild (`build` then `import --fresh`) is scheduled via `.github/workflows/rebuild-cache.yml`, which fires at 06:00 UTC on the 10th of each month and also exposes a `workflow_dispatch` trigger for ad-hoc runs (with an optional `dump_url` input). The workflow expects a `DATABASE_URL_WIKIDATA` repository secret pointing at the destination cache. The 10th-of-the-month cron is staggered against the sister cache rebuilds (`discogs-etl`, `musicbrainz-cache`) so no two multi-hour rebuilds co-run.
+
+**Runner-capacity caveat:** the Wikidata JSON dump is roughly 130GB gzipped and a full rebuild can take many hours. GitHub-hosted `ubuntu-latest` runners have a 6-hour job timeout and only ~14GB of free disk, so the scheduled run will likely fail on disk or timeout. The workflow is intentionally a scheduling skeleton — the actual rebuild needs to migrate to a self-hosted runner, a Railway job, or a dedicated EC2 box. Until then, treat the `workflow_dispatch` trigger as the supported path (e.g., for small-dump smoke tests) and run real rebuilds out-of-band.
+
 ## Development
 
 ### TDD (Required)


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/rebuild-cache.yml` with a monthly `schedule` (06:00 UTC on the 10th) and a `workflow_dispatch` override for ad-hoc runs.
- The job streams the Wikidata dump via `curl | wikidata-cache build - --gzip --data-dir <dir>` then runs `wikidata-cache import --data-dir <dir> --fresh` against the `DATABASE_URL_WIKIDATA` secret.
- Documents the runner-capacity caveat (Wikidata dump is ~130GB gzipped and a full rebuild exceeds both the 6-hour timeout and the ~14GB free-disk budget on `ubuntu-latest`) as TODOs in the workflow file. The skeleton is the deliverable; the actual rebuild needs to migrate to a self-hosted runner, Railway, or EC2.
- Adds a Scheduling section to `CLAUDE.md` covering the cron, dispatch trigger, required secret, and runner-capacity note.

The 10th-of-the-month cron is staggered against the discogs-etl and musicbrainz-cache rebuild schedules so no two multi-hour rebuilds co-run.

## Test plan

- [x] `actionlint .github/workflows/rebuild-cache.yml` passes
- [x] Both `schedule:` and `workflow_dispatch:` triggers present
- [x] Workflow references `secrets.DATABASE_URL_WIKIDATA` (operator-provisioned)
- [x] CLAUDE.md Scheduling section added
- [ ] CI green on this PR
- [ ] After merge: operator provisions `DATABASE_URL_WIKIDATA` secret and decides where the actual rebuild runs

## Tracking

- Parent epic: WXYC/wxyc-etl#47
- Phase: C
- Project: https://github.com/orgs/WXYC/projects/19

Closes #17