### PR TITLE
Adopt sqlx-cli + 0001_initial baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,31 @@ The full rebuild (`build` then `import --fresh`) is scheduled via `.github/workf
 
 **Runner-capacity caveat:** the Wikidata JSON dump is roughly 130GB gzipped and a full rebuild can take many hours. GitHub-hosted `ubuntu-latest` runners have a 6-hour job timeout and only ~14GB of free disk, so the scheduled run will likely fail on disk or timeout. The workflow is intentionally a scheduling skeleton — the actual rebuild needs to migrate to a self-hosted runner, a Railway job, or a dedicated EC2 box. Until then, treat the `workflow_dispatch` trigger as the supported path (e.g., for small-dump smoke tests) and run real rebuilds out-of-band.
 
+## Migrations
+
+Schema changes ship as numbered SQL files under `migrations/`, applied with [sqlx-cli](https://crates.io/crates/sqlx-cli). The baseline `migrations/0001_initial.sql` mirrors `schema/create_database.sql`.
+
+Install sqlx-cli once:
+
+```bash
+cargo install sqlx-cli --no-default-features --features postgres
+```
+
+Add a new migration:
+
+```bash
+sqlx migrate add <descriptive_name>
+# edits a new migrations/000N_<descriptive_name>.sql; write forward-only SQL
+```
+
+Apply against a database (e.g., a fresh local Postgres):
+
+```bash
+sqlx migrate run --database-url postgresql://localhost:5435/<db> --source migrations
+```
+
+**Runtime path is unchanged.** `src/import_schema.rs::apply_schema()` still reads `schema/create_database.sql` on every fresh import; `sqlx migrate run` is not yet wired into the CLI or the deploy pipeline. Switching the runtime over and stamping production with the baseline version is tracked in [WXYC/wxyc-etl#56](https://github.com/WXYC/wxyc-etl/issues/56). Until that lands, keep `schema/create_database.sql` and `migrations/0001_initial.sql` in sync — any schema change should land in both files in the same PR.
+
 ## Development
 
 ### TDD (Required)

--- a/migrations/0001_initial.sql
+++ b/migrations/0001_initial.sql
@@ -1,0 +1,64 @@
+-- wikidata-cache PostgreSQL schema
+-- Creates tables for music-relevant Wikidata entities extracted by wikidata-cache.
+-- Compatible with the 8 CSV files produced by wikidata-cache's writer module.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE TABLE IF NOT EXISTS entity (
+    qid TEXT PRIMARY KEY,
+    label TEXT,
+    description TEXT,
+    entity_type TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_type ON entity(entity_type);
+CREATE INDEX IF NOT EXISTS idx_entity_label_trgm ON entity USING gin(label gin_trgm_ops);
+
+CREATE TABLE IF NOT EXISTS discogs_mapping (
+    qid TEXT NOT NULL REFERENCES entity(qid),
+    property TEXT NOT NULL,
+    discogs_id TEXT NOT NULL,
+    PRIMARY KEY (qid, property, discogs_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_discogs_mapping_property_id ON discogs_mapping(property, discogs_id);
+
+CREATE TABLE IF NOT EXISTS influence (
+    source_qid TEXT NOT NULL REFERENCES entity(qid),
+    target_qid TEXT NOT NULL,
+    PRIMARY KEY (source_qid, target_qid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_influence_target ON influence(target_qid);
+
+CREATE TABLE IF NOT EXISTS genre (
+    entity_qid TEXT NOT NULL REFERENCES entity(qid),
+    genre_qid TEXT NOT NULL,
+    PRIMARY KEY (entity_qid, genre_qid)
+);
+
+CREATE TABLE IF NOT EXISTS record_label (
+    artist_qid TEXT NOT NULL REFERENCES entity(qid),
+    label_qid TEXT NOT NULL,
+    PRIMARY KEY (artist_qid, label_qid)
+);
+
+CREATE TABLE IF NOT EXISTS label_hierarchy (
+    child_qid TEXT NOT NULL,
+    parent_qid TEXT NOT NULL,
+    PRIMARY KEY (child_qid, parent_qid)
+);
+
+CREATE TABLE IF NOT EXISTS entity_alias (
+    qid TEXT NOT NULL REFERENCES entity(qid),
+    alias TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_alias_qid ON entity_alias(qid);
+CREATE INDEX IF NOT EXISTS idx_entity_alias_text_trgm ON entity_alias USING gin(alias gin_trgm_ops);
+
+CREATE TABLE IF NOT EXISTS occupation (
+    entity_qid TEXT NOT NULL REFERENCES entity(qid),
+    occupation_qid TEXT NOT NULL,
+    PRIMARY KEY (entity_qid, occupation_qid)
+);


### PR DESCRIPTION
## Summary

- Add `migrations/0001_initial.sql` mirroring the current `schema/create_database.sql` so future schema changes can ship as numbered sqlx-cli migrations.
- Document sqlx-cli install + workflow in a new `CLAUDE.md` "Migrations" section.
- Runtime path is unchanged: `src/import_schema.rs::apply_schema()` still drives schema creation. Switching the runtime over and stamping production lands in WXYC/wxyc-etl#56.

## Verification

```
cargo install sqlx-cli --no-default-features --features postgres
sqlx migrate run --database-url postgresql://postgres:test@localhost:5448/migtest --source migrations
# Applied 1/migrate initial (33ms)
```

A fresh Postgres 16 container had all 8 tables plus `_sqlx_migrations` after the run.

## Test plan

- [x] `migrations/0001_initial.sql` matches `schema/create_database.sql`
- [x] Applies cleanly to an empty Postgres via `sqlx migrate run`
- [x] CLAUDE.md "Migrations" section landed (install + add + apply + sync caveat)
- [x] No runtime / deploy code changes
- [ ] CI green

## Tracking

Closes #18. Parent epic: WXYC/wxyc-etl#48. Runtime switch + prod stamping tracked in WXYC/wxyc-etl#56.