### PR TITLE
Pin wxyc-etl to 0.1.0 from crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout wxyc-etl at expected relative path
-        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../wxyc-etl"
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -23,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout wxyc-etl at expected relative path
-        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../wxyc-etl"
       - uses: dtolnay/rust-toolchain@stable
       - name: Build tests
         run: cargo build --tests
@@ -49,8 +45,6 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout wxyc-etl at expected relative path
-        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../wxyc-etl"
       - uses: dtolnay/rust-toolchain@stable
       - name: Run PostgreSQL integration tests
         env:

--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -41,9 +41,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Checkout wxyc-etl at expected relative path
-        run: git clone --depth 1 https://github.com/WXYC/wxyc-etl.git "$GITHUB_WORKSPACE/../wxyc-etl"
-
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Build release binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3201,6 +3201,8 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 [[package]]
 name = "wxyc-etl"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e0a1f3339c2fb633a75b09d65fd022c4b1328f2965750097fa60c626930140"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ csv = "1.3"
 anyhow = "1"
 log = "0.4"
 tracing = "0.1"
-wxyc-etl = { path = "../wxyc-etl/wxyc-etl" }
+wxyc-etl = "0.1.0"
 postgres = "0.19"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

- Replaces the `wxyc-etl = { path = "../wxyc-etl/wxyc-etl" }` Cargo dep with `wxyc-etl = "0.1.0"` (exact pin, no version range — staying 0.x lockstep with the rest of the pipeline).
- Drops every `Checkout wxyc-etl at expected relative path` step from `.github/workflows/ci.yml` (lint, test, test-postgres) and `.github/workflows/rebuild-cache.yml`. Cargo now resolves wxyc-etl from crates.io.
- Refreshes `Cargo.lock` against the published `wxyc-etl 0.1.0`.

No code changes; the upstream API matches what was previously consumed via the path-dep.

## Test plan

- [x] `cargo build` succeeds against crates.io
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib --bins --test cli_tests --test oracle_tests --test error_handling` passes
- [ ] CI green on PR

## Tracking

Closes #16. Parent epic: WXYC/wxyc-etl#46.