### PR TITLE
deploy: wire sqlx migrate run into the monthly rebuild

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -46,6 +46,20 @@ jobs:
       - name: Build release binary
         run: cargo build --release
 
+      # Apply pending sqlx migrations against the prod cache before rebuild.
+      # `migrations/0001_initial.sql` (and any future migrations) is idempotent
+      # (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`), so
+      # re-applying against a populated DB is a no-op other than populating the
+      # `_sqlx_migrations` history table. New migrations added between rebuilds
+      # get picked up here so incremental schema changes don't require a full
+      # reimport.
+      - name: Install sqlx-cli
+        run: cargo install --quiet --version 0.8 sqlx-cli --no-default-features --features postgres
+      - name: Apply pending migrations
+        run: sqlx migrate run --source migrations
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL_WIKIDATA }}
+
       - name: Prepare data directory
         run: mkdir -p "$DATA_DIR"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,11 @@ Apply against a database (e.g., a fresh local Postgres):
 sqlx migrate run --database-url postgresql://localhost:5435/<db> --source migrations
 ```
 
-**Runtime path is unchanged.** `src/import_schema.rs::apply_schema()` still reads `schema/create_database.sql` on every fresh import; `sqlx migrate run` is not yet wired into the CLI or the deploy pipeline. Switching the runtime over and stamping production with the baseline version is tracked in [WXYC/wxyc-etl#56](https://github.com/WXYC/wxyc-etl/issues/56). Until that lands, keep `schema/create_database.sql` and `migrations/0001_initial.sql` in sync — any schema change should land in both files in the same PR.
+**Deploy wiring**: `sqlx migrate run` is invoked by `.github/workflows/rebuild-cache.yml` before every monthly rebuild. Every migration in `migrations/` must be idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`) — re-applying against a populated prod DB is required to be a no-op so the rebuild cron stays safe.
+
+**Dual-write convention**: when adding a schema change, write the new `migrations/000N_*.sql` AND mirror it into `schema/create_database.sql` so fresh-rebuild parity holds. The two paths must produce the same end-state.
+
+The `src/import_schema.rs::apply_schema()` runtime path remains the source of truth for fresh-rebuild DDL; `sqlx migrate run` is the source of truth for incremental schema evolution between rebuilds.
 
 ## Development
 


### PR DESCRIPTION
## Summary

Adds an `Apply pending migrations` step to `.github/workflows/rebuild-cache.yml` that runs `sqlx migrate run --source migrations` against the prod cache before the rebuild itself.

`migrations/0001_initial.sql` is idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`), so the first run after this lands creates `_sqlx_migrations`, applies 0001 against the populated DB as a no-op, and records it. Subsequent monthly runs apply only newly-added migrations.

## Phase D scope

This is the wikidata-cache slice of WXYC/wxyc-etl#56. Sister PR for musicbrainz-cache: WXYC/musicbrainz-cache#36. The discogs-etl slice will need a one-shot `alembic stamp head` against prod (operator action) because alembic's baseline isn't idempotent.

Refs WXYC/wxyc-etl#56.
