### PR TITLE
deps: bump wxyc-etl 0.1.0 → 0.3.0 (E3 step 5a)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deunicode"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,14 +3206,15 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wxyc-etl"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e0a1f3339c2fb633a75b09d65fd022c4b1328f2965750097fa60c626930140"
+checksum = "e9f4f32d293cb6ab6d935ebfb343dd0581f0e2592c69e85612c78c05a171339b"
 dependencies = [
  "anyhow",
  "clap",
  "crossbeam-channel",
  "csv",
+ "deunicode",
  "env_logger",
  "itoa",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ csv = "1.3"
 anyhow = "1"
 log = "0.4"
 tracing = "0.1"
-wxyc-etl = "0.1.0"
+wxyc-etl = "0.3.0"
 postgres = "0.19"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary
- Bumps `wxyc-etl` pin from `0.1.0` to `0.3.0`, pulling in the cross-cache-identity normalizers (`to_identity_match_form` family) per [library-hook-canonicalization-plan §3.3.1 step 5](https://github.com/WXYC/wiki/blob/main/plans/library-hook-canonicalization-plan.md).
- This crate has no `wxyc_etl::text::*` callers — only `cli`, `logger`, `pipeline`, and `csv_writer` — so the bump is purely mechanical with no behavior changes.

## Test plan
- [x] `cargo build --workspace` succeeds
- [x] `cargo test --workspace --lib` (26 unit) passes
- [x] `cargo test --workspace --test cli_tests` (10 CLI) passes
- [x] `cargo test --workspace --test import_test` (22 import) passes
- [x] `cargo test --workspace --test pg_import_test` (15 PG, with `TEST_DATABASE_URL`) passes
- [x] `grep -r "wxyc_etl::text" src/` returns no matches

Closes #31
Refs WXYC/wxyc-etl#73 (E3 step 5a)