### PR TITLE
chore(deps): consolidate NUL-strip onto wxyc_etl::pg::to_pg_text_form

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ csv = "1.3"
 anyhow = "1"
 log = "0.4"
 tracing = "0.1"
-wxyc-etl = "0.6.0"
+wxyc-etl = "0.8"
 postgres = "0.19"
 rusqlite = { version = "0.31", features = ["bundled"] }
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -4,6 +4,7 @@
 use anyhow::{Context, Result};
 use postgres::Client;
 use std::path::Path;
+use wxyc_etl::pg::to_pg_text_form;
 
 /// COPY statement for each table, keyed by table name.
 fn copy_stmt(table: &str, columns: &[&str]) -> String {
@@ -45,21 +46,27 @@ const TABLE_DEFS: &[(&str, &str, &[&str])] = &[
 
 /// Escape a string value for PostgreSQL COPY TEXT format.
 ///
-/// Handles backslash, tab, newline, and carriage return. Drops U+0000
-/// (NUL) silently — PostgreSQL TEXT cannot store it (SQL standard), and
-/// per the org-wide WX-3.B policy (WXYC/docs#18) we strip it at every
-/// PG TEXT write boundary. NUL in artist/title metadata is always a
-/// corruption signal, never intentional.
+/// Composes two boundary steps:
 ///
-/// **Caller note**: this function is destructive and intended for the PG
-/// COPY TEXT pipeline only. Do not reuse for human-readable output, log
-/// formatting, or any context where NUL bytes would be useful diagnostic
-/// signal — they're silently swallowed here.
+/// 1. NUL strip via [`wxyc_etl::pg::to_pg_text_form`] — PostgreSQL TEXT
+///    cannot store U+0000 (SQL standard), and per the org-wide WX-3.B
+///    policy (WXYC/docs#18) we strip it at every PG TEXT write boundary.
+///    NUL in artist/title metadata is always a corruption signal, never
+///    intentional. The upstream helper returns `Cow::Borrowed` when no
+///    NUL is present, so the common case stays zero-copy.
+/// 2. COPY-format escape — backslash, tab, newline, and carriage return
+///    are reserved in PG COPY's text format; everything else passes
+///    through unchanged.
+///
+/// **Caller note**: this function is destructive (NUL is silently
+/// swallowed) and intended for the PG COPY TEXT pipeline only. Do not
+/// reuse for human-readable output, log formatting, or any context where
+/// NUL bytes would be useful diagnostic signal.
 fn escape_copy_text(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
+    let stripped = to_pg_text_form(s);
+    let mut out = String::with_capacity(stripped.len());
+    for c in stripped.chars() {
         match c {
-            '\0' => {} // strip at boundary (WXYC/docs#18)
             '\\' => out.push_str("\\\\"),
             '\t' => out.push_str("\\t"),
             '\n' => out.push_str("\\n"),

--- a/src/wxyc_loader.rs
+++ b/src/wxyc_loader.rs
@@ -44,6 +44,7 @@ use std::time::SystemTime;
 
 use anyhow::{Context, Result};
 use postgres::Client;
+use wxyc_etl::pg::to_pg_text_form;
 use wxyc_etl::text::{to_identity_match_form, to_identity_match_form_title};
 
 /// Audit string surfaced in INFO logs and asserted by integration tests.
@@ -181,20 +182,6 @@ fn existing_columns(
     Ok(set)
 }
 
-/// Strip NUL bytes (U+0000) from a TEXT value at the PostgreSQL write
-/// boundary, matching the org-wide WX-3.B policy ([WXYC/docs#18]) and
-/// `import.rs::escape_copy_text`. PostgreSQL TEXT cannot store NUL; in
-/// library metadata it's always corruption, never intentional signal.
-///
-/// [WXYC/docs#18]: https://github.com/WXYC/docs/issues/18
-fn strip_pg_null_bytes(s: &str) -> String {
-    s.chars().filter(|c| *c != '\0').collect()
-}
-
-fn strip_pg_null_bytes_opt(s: Option<&str>) -> Option<String> {
-    s.map(strip_pg_null_bytes)
-}
-
 /// Identity-tier normalization for the optional `norm_label` column.
 ///
 /// `to_identity_match_form` returns an empty string for empty input; we want
@@ -276,12 +263,24 @@ pub fn populate_wxyc_library_v2(
         // pass through into norm_artist / norm_title / norm_label and crash
         // the INSERT — every TEXT column that hits PostgreSQL must have been
         // stripped, including the derived ones.
-        let artist_name = strip_pg_null_bytes(&r.artist_name);
-        let album_title = strip_pg_null_bytes(&r.album_title);
-        let label_name = strip_pg_null_bytes_opt(r.label_name.as_deref());
-        let format_name = strip_pg_null_bytes_opt(r.format_name.as_deref());
-        let wxyc_genre = strip_pg_null_bytes_opt(r.wxyc_genre.as_deref());
-        let call_letters = strip_pg_null_bytes_opt(r.call_letters.as_deref());
+        let artist_name = to_pg_text_form(&r.artist_name).into_owned();
+        let album_title = to_pg_text_form(&r.album_title).into_owned();
+        let label_name = r
+            .label_name
+            .as_deref()
+            .map(|s| to_pg_text_form(s).into_owned());
+        let format_name = r
+            .format_name
+            .as_deref()
+            .map(|s| to_pg_text_form(s).into_owned());
+        let wxyc_genre = r
+            .wxyc_genre
+            .as_deref()
+            .map(|s| to_pg_text_form(s).into_owned());
+        let call_letters = r
+            .call_letters
+            .as_deref()
+            .map(|s| to_pg_text_form(s).into_owned());
 
         // norm_artist / norm_title are NOT NULL per §3.1, but Postgres `NOT
         // NULL` rejects SQL NULL — NOT empty strings. An empty artist or
@@ -349,17 +348,6 @@ pub fn populate_wxyc_library_v2(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn strip_pg_null_bytes_drops_nul() {
-        assert_eq!(strip_pg_null_bytes("a\0b"), "ab");
-        assert_eq!(strip_pg_null_bytes("\0a\0b\0"), "ab");
-    }
-
-    #[test]
-    fn strip_pg_null_bytes_clean_input_unchanged() {
-        assert_eq!(strip_pg_null_bytes("Stereolab"), "Stereolab");
-    }
 
     #[test]
     fn norm_label_passes_none_through() {


### PR DESCRIPTION
## Summary

Step 2 of the WX-3.B follow-up consumer sweep ([WXYC/wxyc-etl#142](https://github.com/WXYC/wxyc-etl/issues/142)). Delegates this repo's NUL-strip arm to `wxyc_etl::pg::to_pg_text_form` so the WXYC/docs#18 PG TEXT U+0000 strip policy lives in one place across the org.

## What changed

- `src/import.rs:58` — `escape_copy_text` is preserved (it does more than NUL strip — it also escapes `\\`, `\\t`, `\\n`, `\\r` for the PG COPY TEXT format), but the NUL-strip arm is now a first pipeline step that calls the upstream helper. Existing single-pass becomes two-pass under delegation; common case (no NULs) stays zero-copy via the upstream `Cow::Borrowed` short-circuit. The five `escape_copy_text_*` tests at L135-160 assert composed behavior and pass unchanged.
- `src/wxyc_loader.rs:190` — local `strip_pg_null_bytes` + `strip_pg_null_bytes_opt` and their two unit tests are gone. The six call-sites use `to_pg_text_form(...).into_owned()` directly.
- `Cargo.toml` — `wxyc-etl = \"0.6.0\"` → `\"0.8\"`.

## Scope note — second helper not in the issue audit

The original [#142](https://github.com/WXYC/wxyc-etl/issues/142) table for this repo called out only `src/import.rs:58` (escape_copy_text). After cloning, I found a second NUL-strip helper at `src/wxyc_loader.rs:190` (`strip_pg_null_bytes`) added later during the cross-cache-identity rollout (E1 §4.1.3) and missed by the issue's audit. Both implement the same WXYC/docs#18 policy. Leaving the second behind would defeat the consolidation goal (\"policy lives in one place\"), so this PR sweeps both. If the reviewer prefers to split the `wxyc_loader.rs` portion into a follow-up, that's straightforward.

## Performance note (already in the issue)

The two-pass behavior added by delegating `escape_copy_text`'s NUL strip:
- No-NUL inputs: zero-copy via upstream `Cow::Borrowed` — same as before.
- NUL-bearing inputs: one extra allocation. Rare in real Wikidata data per the issue.

## CI dependency

This PR bumps to `wxyc-etl = \"0.8\"`. **CI will fail until [WXYC/wxyc-etl#143](https://github.com/WXYC/wxyc-etl/pull/143) merges and a `v0.8.0` tag publishes to crates.io.** The Rust crate API at `wxyc_etl::pg::to_pg_text_form` is unchanged from 0.7.0, so this PR is functionally complete today — it's only the version constraint that needs the publish.

## Test plan

- [x] `cargo test --lib` — 36 tests pass (locally verified with a `[patch.crates-io]` pointer at the 0.8.0 worktree; patch reverted before commit)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] PG import integration tests require `TEST_DATABASE_URL`; will run in CI
- [ ] CI green after [WXYC/wxyc-etl#143](https://github.com/WXYC/wxyc-etl/pull/143) publishes

Towards [WXYC/wxyc-etl#142](https://github.com/WXYC/wxyc-etl/issues/142).