### PR TITLE
ci(rebuild-cache): pin sqlx-cli to 0.8.7

### DIFF
--- a/.github/workflows/rebuild-cache.yml
+++ b/.github/workflows/rebuild-cache.yml
@@ -54,7 +54,7 @@ jobs:
       # get picked up here so incremental schema changes don't require a full
       # reimport.
       - name: Install sqlx-cli
-        run: cargo install --quiet --version 0.8 sqlx-cli --no-default-features --features postgres
+        run: cargo install --quiet --version 0.8.7 sqlx-cli --no-default-features --features postgres
       - name: Apply pending migrations
         run: sqlx migrate run --source migrations
         env:


### PR DESCRIPTION
## Summary

- Current `cargo install` rejects the bare `0.8` minor-version-only argument in `rebuild-cache.yml:57` ("unexpected end of input while parsing minor version number"), which has silently failed the monthly scheduled rebuild on 2026-05-10 and 2026-06-10.
- Pin to the concrete patch version `0.8.7` for reproducibility (no SemVer-range surprise on the next sqlx-cli release).
- Same root cause and fix as the sibling regression in WXYC/musicbrainz-cache#68.

## Test plan

- [ ] CI green on this PR (lint + test + test-postgres).
- [ ] After merge, trigger `rebuild-cache.yml` via `workflow_dispatch` and confirm the Install sqlx-cli step passes (downstream steps will still hit the documented 14 GB / 6 h runner-capacity ceiling — out of scope here).

Closes #53